### PR TITLE
feature/issue-21 Adds sender name to message

### DIFF
--- a/src/createBot.test.ts
+++ b/src/createBot.test.ts
@@ -257,20 +257,14 @@ describe('server functions', () => {
   test('listen for new messages', (): Promise<void> => new Promise(async (resolve, reject) => {
     const payloads = [
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'text',
         text: { body: 'Hello' },
       },
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'image',
@@ -281,10 +275,7 @@ describe('server functions', () => {
         },
       },
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'document',
@@ -297,10 +288,7 @@ describe('server functions', () => {
         },
       },
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'audio',
@@ -312,10 +300,7 @@ describe('server functions', () => {
         },
       },
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'video',
@@ -326,10 +311,7 @@ describe('server functions', () => {
         },
       },
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'sticker',
@@ -340,20 +322,14 @@ describe('server functions', () => {
         },
       },
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'location',
         location: { latitude: 40.7128, longitude: -74.006, name: 'New York' },
       },
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'contacts',
@@ -373,10 +349,7 @@ describe('server functions', () => {
         }],
       },
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'interactive',
@@ -394,10 +367,7 @@ describe('server functions', () => {
         },
       },
       {
-        from: {
-          wa_id: '12345678',
-          name: 'John Doe',
-        },
+        from: '12345678',
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'interactive',
@@ -427,7 +397,7 @@ describe('server functions', () => {
       expect(message).toHaveProperty('type');
       expect(message).toHaveProperty('data');
 
-      expect(typeof message.from).toBe('object');
+      expect(typeof message.from).toBe('string');
       expect(typeof message.id).toBe('string');
       expect(typeof message.timestamp).toBe('string');
       expect(typeof message.type).toBe('string');

--- a/src/createBot.test.ts
+++ b/src/createBot.test.ts
@@ -257,14 +257,20 @@ describe('server functions', () => {
   test('listen for new messages', (): Promise<void> => new Promise(async (resolve, reject) => {
     const payloads = [
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'text',
         text: { body: 'Hello' },
       },
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'image',
@@ -275,7 +281,10 @@ describe('server functions', () => {
         },
       },
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'document',
@@ -288,7 +297,10 @@ describe('server functions', () => {
         },
       },
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'audio',
@@ -300,7 +312,10 @@ describe('server functions', () => {
         },
       },
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'video',
@@ -311,7 +326,10 @@ describe('server functions', () => {
         },
       },
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'sticker',
@@ -322,14 +340,20 @@ describe('server functions', () => {
         },
       },
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'location',
         location: { latitude: 40.7128, longitude: -74.006, name: 'New York' },
       },
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'contacts',
@@ -349,7 +373,10 @@ describe('server functions', () => {
         }],
       },
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'interactive',
@@ -367,7 +394,10 @@ describe('server functions', () => {
         },
       },
       {
-        from: '12345678',
+        from: {
+          wa_id: '12345678',
+          name: 'John Doe',
+        },
         id: 'wamid.abcd',
         timestamp: '1640995200',
         type: 'interactive',
@@ -397,7 +427,7 @@ describe('server functions', () => {
       expect(message).toHaveProperty('type');
       expect(message).toHaveProperty('data');
 
-      expect(typeof message.from).toBe('string');
+      expect(typeof message.from).toBe('object');
       expect(typeof message.id).toBe('string');
       expect(typeof message.timestamp).toBe('string');
       expect(typeof message.type).toBe('string');

--- a/src/createBot.types.ts
+++ b/src/createBot.types.ts
@@ -6,7 +6,10 @@ import { FreeFormObject } from './utils/misc';
 import { PubSubEvent } from './utils/pubSub';
 
 export interface Message {
-  from: string;
+  from: {
+    wa_id: string,
+    name?: string
+  };
   id: string;
   timestamp: string;
   type: PubSubEvent;

--- a/src/createBot.types.ts
+++ b/src/createBot.types.ts
@@ -6,10 +6,8 @@ import { FreeFormObject } from './utils/misc';
 import { PubSubEvent } from './utils/pubSub';
 
 export interface Message {
-  from: {
-    wa_id: string,
-    name?: string
-  };
+  from: string,
+  name?: string
   id: string;
   timestamp: string;
   type: PubSubEvent;

--- a/src/startExpressServer.ts
+++ b/src/startExpressServer.ts
@@ -115,8 +115,7 @@ export const startExpressServer = (
       };
     }
 
-    const name = req.body.entry[0].changes[0].value.contacts?.length
-      ? req.body.entry[0].changes[0].value.contacts[0].profile.name : undefined;
+    const name = req.body.entry[0].changes[0].value.contacts?.[0]?.profile?.name ?? undefined;
 
     if (event && data) {
       let payload: Message = {

--- a/src/startExpressServer.ts
+++ b/src/startExpressServer.ts
@@ -111,9 +111,15 @@ export const startExpressServer = (
       data!.context ??= rest.context;
     }
 
+    const name = req.body.entry[0].changes[0].value.contacts?.length
+      ? req.body.entry[0].changes[0].value.contacts[0].profile.name : null;
+
     if (event && data) {
       ['message', event].forEach((e) => PubSub.publish(e, {
-        from,
+        from: {
+          wa_id: from,
+          name,
+        },
         id,
         timestamp,
         type: event,


### PR DESCRIPTION
This fix #21 

Adds sender name to message. Changes "from" field to object with wa_id (sender number) and name