### PR TITLE
Pull Request for trying to read status response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ config/test.json
 src/config.json
 
 example/
+log.txt

--- a/src/createBot.types.ts
+++ b/src/createBot.types.ts
@@ -13,6 +13,30 @@ export interface Message {
   type: PubSubEvent;
   data: FreeFormObject; // TODO: properly define interfaces for each type
 }
+// https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components
+export interface Status {
+  id: string;
+  status: 'read' | 'delivered' | 'sent' | 'failed';
+  timestamp: string;
+  recipient_id: string;
+  errors?: { // only in failed
+    code: string,
+    title: string,
+    href: string
+  }[];
+  conversation?: { // only in sent and delivered
+    id: string,
+    expiration_timestamp?: string, // only in delivered
+    origin: {
+      type: 'business_initiated' | 'referral_conversion' | 'customer_initiated'
+    },
+  }
+  pricing?: { // only in sent and delivered
+    billable: boolean,
+    pricing_model: 'CBP',
+    category: 'business_initiated' | 'referral_conversion' | 'customer_initiated'
+  }
+}
 
 export interface Bot {
   startExpressServer: (options?: {
@@ -22,7 +46,7 @@ export interface Bot {
     webhookPath?: string;
     webhookVerifyToken?: string;
   }) => Promise<{ server?: Server; app: Application; }>;
-  on: (event: PubSubEvent, cb: (message: Message) => void) => void;
+  on: (event: PubSubEvent, cb: (message: Message | Status) => void) => void;
 
   sendText: (to: string, text: string, options?: {
     preview_url?: boolean;

--- a/src/startExpressServer.ts
+++ b/src/startExpressServer.ts
@@ -64,73 +64,113 @@ export const startExpressServer = (
       res.sendStatus(400);
       return;
     }
-    if (req.body?.entry?.[0]?.changes?.[0]?.value?.statuses) {
-      res.sendStatus(202);
+    if (req.body?.entry?.[0]?.changes?.[0]?.value?.statuses?.[0]) {
+      // console.log('statuses_express');
+      const {
+        id,
+        status,
+        timestamp,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        recipient_id,
+        ...rest
+      } = req.body.entry[0].changes[0].value.statuses[0];
+      let event: PubSubEvent | undefined;
+      let errors: FreeFormObject[] | undefined;
+      let conversation: FreeFormObject | undefined;
+      let pricing: FreeFormObject | undefined;
+      switch (status) {
+        case 'read':
+          event = PubSubEvents.read;
+          break;
+        case 'sent':
+          event = PubSubEvents.sent;
+          conversation = rest.conversation;
+          pricing = rest.pricing;
+          break;
+        case 'delivered':
+          event = PubSubEvents.delivered;
+          conversation = rest.conversation;
+          pricing = rest.pricing;
+          break;
+        case 'failed':
+          event = PubSubEvents.failed;
+          errors = rest.errors;
+          break;
+        default:
+          break;
+      }
+      if (event) {
+        let payload:FreeFormObject = {
+          id,
+          status,
+          timestamp,
+          recipient_id,
+        };
+        if (errors) { payload = { ...payload, errors }; }
+        if (conversation) { payload = { ...payload, conversation }; }
+        if (pricing) { payload = { ...payload, pricing }; }
+        ['status', event].forEach((e) => PubSub.publish(e, payload));
+      }
+      res.sendStatus(200);
       return;
     }
-
-    const {
-      from,
-      id,
-      timestamp,
-      type,
-      ...rest
-    } = req.body.entry[0].changes[0].value.messages[0];
-
-    let event: PubSubEvent | undefined;
-    let data: FreeFormObject | undefined;
-
-    switch (type) {
-      case 'text':
-        event = PubSubEvents.text;
-        data = { text: rest.text?.body };
-        break;
-
-      case 'image':
-      case 'document':
-      case 'audio':
-      case 'video':
-      case 'sticker':
-      case 'location':
-      case 'contacts':
-        event = PubSubEvents[type as PubSubEvent];
-        data = rest[type];
-        break;
-
-      case 'interactive':
-        event = rest.interactive.type;
-        data = {
-          ...(rest.interactive.list_reply || rest.interactive.button_reply),
-        };
-        break;
-
-      default:
-        break;
-    }
-
-    if (rest.context) {
-      data = {
-        ...data,
-        context: rest.context,
-      };
-    }
-
-    const name = req.body.entry[0].changes[0].value.contacts?.[0]?.profile?.name ?? undefined;
-
-    if (event && data) {
-      const payload: Message = {
+    if (req.body?.entry?.[0]?.changes?.[0]?.value?.messages) {
+      console.log('messages_express');
+      const {
         from,
-        name,
         id,
         timestamp,
-        type: event,
-        data,
-      };
-
-      ['message', event].forEach((e) => PubSub.publish(e, payload));
+        type,
+        ...rest
+      } = req.body.entry[0].changes[0].value.messages[0];
+      let event: PubSubEvent | undefined;
+      let data: FreeFormObject | undefined;
+      switch (type) {
+        case 'text':
+          event = PubSubEvents.text;
+          data = { text: rest.text?.body };
+          break;
+        case 'image':
+        case 'document':
+        case 'audio':
+        case 'video':
+        case 'sticker':
+        case 'location':
+        case 'contacts':
+          event = PubSubEvents[type as PubSubEvent];
+          data = rest[type];
+          break;
+        case 'interactive':
+          event = rest.interactive.type;
+          data = {
+            ...(rest.interactive.list_reply || rest.interactive.button_reply),
+          };
+          break;
+        default:
+          break;
+      }
+      if (rest.context) {
+        data = {
+          ...data,
+          context: rest.context,
+        };
+      }
+      const name = req.body.entry[0].changes[0].value.contacts?.[0]?.profile?.name ?? undefined;
+      if (event && data) {
+        const payload: Message = {
+          from,
+          name,
+          id,
+          timestamp,
+          type: event,
+          data,
+        };
+        ['message', event].forEach((e) => PubSub.publish(e, payload));
+      }
+      res.sendStatus(200);
+      return;
     }
-
-    res.sendStatus(200);
+    res.sendStatus(400);
   });
 
   if (options?.app) {

--- a/src/utils/pubSub.ts
+++ b/src/utils/pubSub.ts
@@ -10,6 +10,11 @@ export enum PubSubEvents {
   contacts = 'contacts',
   button_reply = 'button_reply',
   list_reply = 'list_reply',
+  status = 'status',
+  read = 'read',
+  delivered = 'delivered',
+  sent = 'sent',
+  failed = 'failed',
 }
 
 export type PubSubEvent = keyof typeof PubSubEvents;


### PR DESCRIPTION
- Added 'Status' types in`createBot.types.ts` according to https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components
- Changed `on` callback parameter to also accept `Status`
- Will now publish 'status' and '\<status-type\>' to PubSub when receiving only status
- Add new tests to also test for the statuses.

![image](https://user-images.githubusercontent.com/20208219/198014771-9870c0cd-b36d-4c61-add2-45df14335a49.png)

- In addition, also added the `log()` function to console.log to a log.txt in root directory for debugging purposes (can be removed)