### PR TITLE
Implemented template quick replies

### DIFF
--- a/src/createBot.test.ts
+++ b/src/createBot.test.ts
@@ -393,6 +393,20 @@ describe('server functions', () => {
           id: 'wamid.abcd',
         },
       },
+      {
+        from: '12345678',
+        id: 'wamid.abcd',
+        timestamp: '1640995200',
+        type: 'button',
+        button: {
+          payload: "No-Button-Payload",
+          text: "No"
+        },
+        context: {
+          from: '12345678',
+          id: 'wamid.abcd',
+        },
+      },
     ];
 
     let i = 0;
@@ -489,7 +503,19 @@ describe('server functions', () => {
           expect(typeof data.context.from).toBe('string');
           expect(typeof data.context.id).toBe('string');
           break;
+        case 'template_button_reply':
+          expect(data).toHaveProperty('payload');
+          expect(data).toHaveProperty('text');
 
+          expect(typeof data.payload).toBe('string');
+          expect(typeof data.text).toBe('string');
+
+          expect(typeof data.context === 'object').toBe(true);
+          expect(data.context).toHaveProperty('from');
+          expect(data.context).toHaveProperty('id');
+
+          expect(typeof data.context.from).toBe('string');
+          expect(typeof data.context.id).toBe('string');
         default:
           break;
       }

--- a/src/createBot.test.ts
+++ b/src/createBot.test.ts
@@ -399,8 +399,8 @@ describe('server functions', () => {
         timestamp: '1640995200',
         type: 'button',
         button: {
-          payload: "No-Button-Payload",
-          text: "No"
+          payload: 'No-Button-Payload',
+          text: 'No'
         },
         context: {
           from: '12345678',
@@ -516,6 +516,7 @@ describe('server functions', () => {
 
           expect(typeof data.context.from).toBe('string');
           expect(typeof data.context.id).toBe('string');
+          break;
         default:
           break;
       }

--- a/src/createBot.test.ts
+++ b/src/createBot.test.ts
@@ -400,7 +400,7 @@ describe('server functions', () => {
         type: 'button',
         button: {
           payload: 'No-Button-Payload',
-          text: 'No'
+          text: 'No',
         },
         context: {
           from: '12345678',

--- a/src/startExpressServer.ts
+++ b/src/startExpressServer.ts
@@ -107,7 +107,7 @@ export const startExpressServer = (
         event = PubSubEvents.template_button_reply;
         data = {
           ...(rest.button),
-        }
+        };
         break;
       default:
         break;

--- a/src/startExpressServer.ts
+++ b/src/startExpressServer.ts
@@ -103,7 +103,12 @@ export const startExpressServer = (
           ...(rest.interactive.list_reply || rest.interactive.button_reply),
         };
         break;
-
+      case 'button':
+        event = PubSubEvents.template_button_reply;
+        data = {
+          ...(rest.button),
+        }
+        break;
       default:
         break;
     }

--- a/src/utils/pubSub.ts
+++ b/src/utils/pubSub.ts
@@ -9,6 +9,7 @@ export enum PubSubEvents {
   location = 'location',
   contacts = 'contacts',
   button_reply = 'button_reply',
+  template_button_reply = 'template_button_reply',
   list_reply = 'list_reply',
 }
 


### PR DESCRIPTION
Now we can handle the quick reply buttons sent as part of a template.

More info: https://developers.facebook.com/docs/whatsapp/api/messages/message-templates/interactive-message-templates/#callback-from-a-quick-reply-button-click

This fixes #52